### PR TITLE
리워드 아이템 뷰 수정된 디자인 적용

### DIFF
--- a/design-system/src/main/java/com/danbam/design_system/component/Item.kt
+++ b/design-system/src/main/java/com/danbam/design_system/component/Item.kt
@@ -1,6 +1,7 @@
 package com.danbam.design_system.component
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.indication
@@ -11,17 +12,22 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
@@ -39,6 +45,11 @@ import com.danbam.design_system.util.indiStrawClickable
 import com.danbam.design_system.util.toCommaString
 import com.danbam.domain.entity.FundingDetailEntity
 import com.danbam.domain.entity.FundingEntity
+
+sealed class RewardType {
+    object Default : RewardType()
+    object Expand : RewardType()
+}
 
 @Composable
 fun FundingItem(
@@ -135,69 +146,145 @@ fun MovieTvItem(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun RewardItem(
+    rewardType: RewardType = RewardType.Default,
     item: FundingDetailEntity.RewardEntity,
+    onClickItem: (FundingDetailEntity.RewardEntity) -> Unit = {},
     onDelete: (() -> Unit)? = null
 ) {
-    val rewardImageSize = LocalConfiguration.current.screenWidthDp * 0.3
-    Box(
-        modifier = Modifier
-            .padding(horizontal = 15.dp)
-            .fillMaxWidth()
-    ) {
-        Row(
-            modifier = Modifier
-                .padding(
-                    if (onDelete != null) {
-                        PaddingValues(top = 4.dp, end = 4.dp)
-                    } else PaddingValues()
-                )
-                .fillMaxWidth()
-                .background(
-                    color = IndiStrawTheme.colors.darkGray,
-                    shape = IndiStrawTheme.shapes.defaultRounded
-                )
-                .padding(12.dp)
-        ) {
-            AsyncImage(
-                modifier = Modifier
-                    .size(rewardImageSize.dp)
-                    .align(Alignment.CenterVertically)
-                    .clip(IndiStrawTheme.shapes.smallRounded),
-                model = item.imageUrl,
-                contentDescription = "crowdFundingImg",
-                contentScale = ContentScale.Crop
-            )
-            Spacer(modifier = Modifier.width(12.dp))
+    val rewardImageSize = LocalConfiguration.current.screenWidthDp * 0.45
+    when (rewardType) {
+        is RewardType.Default -> {
             Column(
                 modifier = Modifier
-                    .weight(1F)
-                    .height(rewardImageSize.dp)
+                    .padding(horizontal = 15.dp)
+                    .fillMaxWidth()
+                    .background(
+                        color = IndiStrawTheme.colors.darkGray,
+                        shape = IndiStrawTheme.shapes.defaultRounded
+                    )
+                    .padding(horizontal = 12.dp)
+                    .padding(top = 8.dp, bottom = 20.dp)
+                    .indiStrawClickable { onClickItem(item) }
             ) {
-                HeadLineBold(
+                TitleSemiBold(
                     text = item.title,
-                    fontSize = 14,
+                    fontSize = 16,
                     maxLines = 1
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 TitleRegular(
                     text = item.description,
                     color = IndiStrawTheme.colors.gray,
-                    maxLines = 2,
+                    maxLines = 1,
                     fontSize = 14
                 )
-                Spacer(modifier = Modifier.weight(1F))
-                TitleSemiBold(text = "${item.price.toCommaString()}원")
+                Spacer(modifier = Modifier.height(25.dp))
+                Row {
+                    TitleSemiBold(text = "${item.price.toCommaString()}원")
+                    Spacer(modifier = Modifier.width(8.dp))
+                    PriceRegular(
+                        modifier = Modifier
+                            .background(
+                                IndiStrawTheme.colors.main,
+                                IndiStrawTheme.shapes.smallRounded
+                            )
+                            .padding(horizontal = 5.dp, vertical = 1.dp),
+                        text = "1개 남음",
+                        fontSize = 12,
+                    )
+                }
             }
         }
-        onDelete?.let {
-            IndiStrawIcon(
+
+        is RewardType.Expand -> {
+            val state = rememberPagerState()
+            Box(
                 modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .indiStrawClickable(onClick = onDelete),
-                icon = IndiStrawIconList.Delete
-            )
+                    .padding(horizontal = 15.dp)
+                    .fillMaxWidth()
+            ) {
+                Column(
+                    modifier = Modifier
+                        .padding(
+                            if (onDelete != null) PaddingValues(
+                                end = 4.dp,
+                                top = 4.dp
+                            ) else PaddingValues()
+                        )
+                        .background(
+                            if (onDelete != null) IndiStrawTheme.colors.darkGray3 else Color.Transparent,
+                            IndiStrawTheme.shapes.bigRounded
+                        )
+                        .padding(if (onDelete != null) PaddingValues(12.dp) else PaddingValues())
+                ) {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Box {
+                        HorizontalPager(pageCount = 4, state = state) {
+                            AsyncImage(
+                                modifier = Modifier
+                                    .clip(IndiStrawTheme.shapes.defaultRounded)
+                                    .height(rewardImageSize.dp)
+                                    .fillMaxWidth(),
+                                model = item.imageUrl, contentDescription = "rewardThumbnail",
+                                contentScale = ContentScale.Crop
+                            )
+                        }
+                        TitleRegular(
+                            modifier = Modifier
+                                .alpha(0.7F)
+                                .align(Alignment.BottomEnd)
+                                .padding(end = 8.dp, bottom = 8.dp)
+                                .background(
+                                    IndiStrawTheme.colors.gray3,
+                                    IndiStrawTheme.shapes.smallRounded
+                                )
+                                .padding(horizontal = 10.dp, vertical = 1.dp),
+                            text = "${state.currentPage + 1} / 4"
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                    TitleSemiBold(text = item.title, fontSize = 16)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    TitleRegular(
+                        text = item.title,
+                        fontSize = 14,
+                        color = IndiStrawTheme.colors.gray
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row {
+                        ExampleTextMedium(text = "${item.price.toCommaString()}원", fontSize = 16)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        PriceRegular(
+                            modifier = Modifier
+                                .background(
+                                    IndiStrawTheme.colors.main,
+                                    IndiStrawTheme.shapes.smallRounded
+                                )
+                                .padding(horizontal = 5.dp, vertical = 1.dp),
+                            text = "1개 남음",
+                            fontSize = 12,
+                        )
+                    }
+                    if (onDelete == null) {
+                        Spacer(modifier = Modifier.height(41.dp))
+                        IndiStrawButton(text = stringResource(id = R.string.choose_reward)) {
+
+                        }
+                        Spacer(modifier = Modifier.height(35.dp))
+                    }
+                }
+                onDelete?.let {
+                    IndiStrawIcon(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .indiStrawClickable(onClick = onDelete),
+                        icon = IndiStrawIconList.Delete
+                    )
+                }
+            }
         }
     }
 }

--- a/mobile/src/main/java/com/danbam/mobile/ui/funding/detail/FundingDetailScreen.kt
+++ b/mobile/src/main/java/com/danbam/mobile/ui/funding/detail/FundingDetailScreen.kt
@@ -8,9 +8,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Divider
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,11 +42,15 @@ import com.danbam.design_system.component.TitleSemiBold
 import com.danbam.design_system.R
 import com.danbam.design_system.attribute.IndiStrawIcon
 import com.danbam.design_system.attribute.IndiStrawIconList
+import com.danbam.design_system.component.IndiStrawBottomSheetLayout
 import com.danbam.design_system.component.IndiStrawSlider
 import com.danbam.design_system.component.RewardItem
+import com.danbam.design_system.component.RewardType
 import com.danbam.design_system.util.toCommaString
+import com.danbam.domain.entity.FundingDetailEntity
 import com.danbam.mobile.util.parser.toCommaString
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun FundingDetailScreen(
     navController: NavController,
@@ -53,164 +62,169 @@ fun FundingDetailScreen(
     val sideEffect = container.sideEffectFlow
 
     val fundingHeight = LocalConfiguration.current.screenHeightDp * 0.3
+    var selectRewardItem: FundingDetailEntity.RewardEntity? by remember { mutableStateOf(null) }
 
     LaunchedEffect(Unit) {
         fundingDetailViewModel.getDetail(fundingIndex = fundingIndex)
     }
 
-    IndiStrawColumnBackground(
-        scrollEnabled = true
-    ) {
-        IndiStrawHeader(
-            pressBackBtn = { navController.popBackStack() }
-        )
-        AsyncImage(
-            modifier = Modifier
-                .padding(top = 30.dp)
-                .height(fundingHeight.dp)
-                .fillMaxWidth(),
-            model = state.fundingDetailEntity.thumbnailUrl,
-            contentDescription = "fundingBanner",
-            contentScale = ContentScale.Crop
-        )
-        FindPasswordMedium(
-            modifier = Modifier.padding(start = 15.dp, top = 12.dp),
-            text = "${stringResource(id = R.string.mc)}: ${state.fundingDetailEntity.writer.name}",
-            color = IndiStrawTheme.colors.lightGray
-        )
-        ButtonMedium(
-            modifier = Modifier.padding(15.dp, top = 8.dp),
-            text = state.fundingDetailEntity.title
-        )
-        Row(
-            modifier = Modifier.padding(start = 15.dp, top = 16.dp),
-            verticalAlignment = Alignment.Bottom
-        ) {
-            HeadLineBold(
-                text = state.fundingDetailEntity.amount.percentage.toInt().toString(),
-                fontSize = 18,
-                color = IndiStrawTheme.colors.main
-            )
-            ExampleTextMedium(text = "%", fontSize = 12, color = IndiStrawTheme.colors.main)
-            Spacer(modifier = Modifier.width(4.dp))
-            ExampleTextRegular(
-                text = stringResource(id = R.string.complete),
-                fontSize = 14,
-                color = IndiStrawTheme.colors.main
-            )
-            Spacer(modifier = Modifier.width(10.dp))
-            ExampleTextMedium(
-                modifier = Modifier
-                    .background(
-                        color = IndiStrawTheme.colors.main,
-                        shape = IndiStrawTheme.shapes.smallRounded
-                    )
-                    .padding(horizontal = 4.dp, vertical = 1.dp),
-                text = "D-${state.fundingDetailEntity.remainingDay}",
-                fontSize = 12
-            )
+    IndiStrawBottomSheetLayout(sheetContent = {
+        selectRewardItem?.let {
+            RewardItem(rewardType = RewardType.Expand, item = it)
         }
-        Row(
-            modifier = Modifier.padding(start = 15.dp, top = 9.dp),
-            verticalAlignment = Alignment.Bottom
+    }) { _, openSheet ->
+        IndiStrawColumnBackground(
+            scrollEnabled = true
         ) {
-            TitleSemiBold(
-                text = state.fundingDetailEntity.amount.totalAmount.toCommaString(),
-                fontSize = 18
+            IndiStrawHeader(
+                pressBackBtn = { navController.popBackStack() }
             )
-            TitleSemiBold(
-                text = "/${state.fundingDetailEntity.amount.targetAmount.toCommaString()}",
-                fontSize = 18,
+            AsyncImage(
+                modifier = Modifier
+                    .padding(top = 30.dp)
+                    .height(fundingHeight.dp)
+                    .fillMaxWidth(),
+                model = state.fundingDetailEntity.thumbnailUrl,
+                contentDescription = "fundingBanner",
+                contentScale = ContentScale.Crop
+            )
+            FindPasswordMedium(
+                modifier = Modifier.padding(start = 15.dp, top = 12.dp),
+                text = "${stringResource(id = R.string.mc)}: ${state.fundingDetailEntity.writer.name}",
                 color = IndiStrawTheme.colors.lightGray
             )
-            Spacer(modifier = Modifier.width(4.dp))
-            ExampleTextRegular(text = stringResource(id = R.string.money_unit))
-            Spacer(modifier = Modifier.width(8.dp))
+            ButtonMedium(
+                modifier = Modifier.padding(15.dp, top = 8.dp),
+                text = state.fundingDetailEntity.title
+            )
             Row(
-                modifier = Modifier
-                    .background(
-                        color = IndiStrawTheme.colors.darkGray,
-                        shape = IndiStrawTheme.shapes.smallRounded
-                    )
-                    .padding(horizontal = 4.dp, vertical = 1.dp),
+                modifier = Modifier.padding(start = 15.dp, top = 16.dp),
+                verticalAlignment = Alignment.Bottom
             ) {
-                IndiStrawIcon(icon = IndiStrawIconList.People)
-                Spacer(modifier = Modifier.width(2.dp))
+                HeadLineBold(
+                    text = state.fundingDetailEntity.amount.percentage.toInt().toString(),
+                    fontSize = 18,
+                    color = IndiStrawTheme.colors.main
+                )
+                ExampleTextMedium(text = "%", fontSize = 12, color = IndiStrawTheme.colors.main)
+                Spacer(modifier = Modifier.width(4.dp))
+                ExampleTextRegular(
+                    text = stringResource(id = R.string.complete),
+                    fontSize = 14,
+                    color = IndiStrawTheme.colors.main
+                )
+                Spacer(modifier = Modifier.width(10.dp))
                 ExampleTextMedium(
-                    text = state.fundingDetailEntity.fundingCount.toCommaString(),
-                    color = IndiStrawTheme.colors.lightGray,
+                    modifier = Modifier
+                        .background(
+                            color = IndiStrawTheme.colors.main,
+                            shape = IndiStrawTheme.shapes.smallRounded
+                        )
+                        .padding(horizontal = 4.dp, vertical = 1.dp),
+                    text = "D-${state.fundingDetailEntity.remainingDay}",
                     fontSize = 12
                 )
             }
-        }
-        IndiStrawProgress(
-            modifier = Modifier.padding(start = 15.dp, end = 15.dp, top = 20.dp),
-            currentProgress = state.fundingDetailEntity.amount.percentage,
-            enableText = false
-        )
-        Divider(
-            modifier = Modifier
-                .padding(vertical = 28.dp)
-                .fillMaxWidth()
-                .height(1.dp)
-                .background(IndiStrawTheme.colors.darkGray)
-        )
-        TitleRegular(
-            modifier = Modifier.padding(horizontal = 15.dp),
-            text = state.fundingDetailEntity.description
-        )
-        IndiStrawSlider(itemCount = state.fundingDetailEntity.imageList.size) {
-            AsyncImage(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 15.dp)
-                    .clip(IndiStrawTheme.shapes.defaultRounded),
-                model = state.fundingDetailEntity.imageList[it],
-                contentDescription = "fundingImage",
-                contentScale = ContentScale.Crop
-            )
-        }
-        HeadLineBold(
-            modifier = Modifier.padding(start = 15.dp, top = 28.dp),
-            text = stringResource(id = R.string.attached_file),
-            fontSize = 16
-        )
-        repeat(state.fundingDetailEntity.fileList.size) {
             Row(
-                modifier = Modifier.padding(start = 15.dp, end = 15.dp, top = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
+                modifier = Modifier.padding(start = 15.dp, top = 9.dp),
+                verticalAlignment = Alignment.Bottom
             ) {
-                IndiStrawIcon(icon = IndiStrawIconList.Attached)
+                TitleSemiBold(
+                    text = state.fundingDetailEntity.amount.totalAmount.toCommaString(),
+                    fontSize = 18
+                )
+                TitleSemiBold(
+                    text = "/${state.fundingDetailEntity.amount.targetAmount.toCommaString()}",
+                    fontSize = 18,
+                    color = IndiStrawTheme.colors.lightGray
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                ExampleTextRegular(text = stringResource(id = R.string.money_unit))
                 Spacer(modifier = Modifier.width(8.dp))
-                TitleRegular(
-                    text = state.fundingDetailEntity.fileList[it],
-                    fontSize = 14,
-                    color = IndiStrawTheme.colors.skyBlue
+                Row(
+                    modifier = Modifier
+                        .background(
+                            color = IndiStrawTheme.colors.darkGray,
+                            shape = IndiStrawTheme.shapes.smallRounded
+                        )
+                        .padding(horizontal = 4.dp, vertical = 1.dp),
+                ) {
+                    IndiStrawIcon(icon = IndiStrawIconList.People)
+                    Spacer(modifier = Modifier.width(2.dp))
+                    ExampleTextMedium(
+                        text = state.fundingDetailEntity.fundingCount.toCommaString(),
+                        color = IndiStrawTheme.colors.lightGray,
+                        fontSize = 12
+                    )
+                }
+            }
+            IndiStrawProgress(
+                modifier = Modifier.padding(start = 15.dp, end = 15.dp, top = 20.dp),
+                currentProgress = state.fundingDetailEntity.amount.percentage,
+                enableText = false
+            )
+            Divider(
+                modifier = Modifier
+                    .padding(vertical = 28.dp)
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(IndiStrawTheme.colors.darkGray)
+            )
+            TitleRegular(
+                modifier = Modifier.padding(horizontal = 15.dp),
+                text = state.fundingDetailEntity.description
+            )
+            IndiStrawSlider(itemCount = state.fundingDetailEntity.imageList.size) {
+                AsyncImage(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 15.dp)
+                        .clip(IndiStrawTheme.shapes.defaultRounded),
+                    model = state.fundingDetailEntity.imageList[it],
+                    contentDescription = "fundingImage",
+                    contentScale = ContentScale.Crop
                 )
             }
-        }
-        Divider(
-            modifier = Modifier
-                .padding(vertical = 28.dp)
-                .fillMaxWidth()
-                .height(1.dp)
-                .background(IndiStrawTheme.colors.darkGray)
-        )
-        DialogMedium(
-            modifier = Modifier.padding(start = 15.dp, bottom = 16.dp), text = stringResource(
-                id = R.string.choose_reward
+            HeadLineBold(
+                modifier = Modifier.padding(start = 15.dp, top = 28.dp),
+                text = stringResource(id = R.string.attached_file),
+                fontSize = 16
             )
-        )
-        repeat(state.fundingDetailEntity.reward.size) {
-            RewardItem(item = state.fundingDetailEntity.reward[it])
-            Spacer(modifier = Modifier.height(16.dp))
-        }
-        IndiStrawButton(
-            modifier = Modifier.padding(top = 21.dp, bottom = 160.dp), text = stringResource(
-                id = R.string.do_funding
+            repeat(state.fundingDetailEntity.fileList.size) {
+                Row(
+                    modifier = Modifier.padding(start = 15.dp, end = 15.dp, top = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IndiStrawIcon(icon = IndiStrawIconList.Attached)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    TitleRegular(
+                        text = state.fundingDetailEntity.fileList[it],
+                        fontSize = 14,
+                        color = IndiStrawTheme.colors.skyBlue
+                    )
+                }
+            }
+            Divider(
+                modifier = Modifier
+                    .padding(vertical = 28.dp)
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(IndiStrawTheme.colors.darkGray)
             )
-        ) {
+            DialogMedium(
+                modifier = Modifier.padding(start = 15.dp, bottom = 16.dp), text = stringResource(
+                    id = R.string.choose_reward
+                )
+            )
+            repeat(state.fundingDetailEntity.reward.size) {
+                RewardItem(item = state.fundingDetailEntity.reward[it], onClickItem = {
+                    selectRewardItem = it
+                    openSheet()
 
+                })
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+            Spacer(modifier = Modifier.height(54.dp))
         }
     }
 }

--- a/mobile/src/main/java/com/danbam/mobile/ui/funding/make/AddRewardScreen.kt
+++ b/mobile/src/main/java/com/danbam/mobile/ui/funding/make/AddRewardScreen.kt
@@ -23,6 +23,7 @@ import com.danbam.design_system.attribute.IndiStrawIcon
 import com.danbam.design_system.attribute.IndiStrawIconList
 import com.danbam.design_system.component.HeadLineBold
 import com.danbam.design_system.component.RewardItem
+import com.danbam.design_system.component.RewardType
 import com.danbam.design_system.component.TitleRegular
 import com.danbam.design_system.util.RemoveOverScrollLazyColumn
 import com.danbam.design_system.util.indiStrawClickable
@@ -50,6 +51,7 @@ fun AddRewardScreen(
         ) {
             itemsIndexed(state.rewardList) { index, item ->
                 RewardItem(
+                    rewardType = RewardType.Expand,
                     item = FundingDetailEntity.RewardEntity(
                         title = item.title,
                         description = item.description,


### PR DESCRIPTION
## 작업 내용
- 리워드 아이템 뷰 수정된 디자인 적용
- 펀딩 디테일 페이지에서 클릭시 바텀 시트 띄우기